### PR TITLE
Update to guardian/thrift-swift@v0.21.0-gu1

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         // .package(url: /* package url */, from: "1.0.0"),
-        .package(url: "https://github.com/guardian/thrift-swift.git", .upToNextMinor(from: "0.19.0-gu1"))
+        .package(url: "https://github.com/guardian/thrift-swift.git", .upToNextMinor(from: "0.21.0-gu1"))
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.


### PR DESCRIPTION
## What does this change?
Once https://github.com/guardian/thrift-swift/pull/10 is merged, we can update bridget-swift to use the latest release of guardian/thrift-swift.

When https://github.com/guardian/bridget/pull/179 is merged, we'll create a new release of Bridget. That will cause a new tag to be [created](https://github.com/guardian/bridget/blob/c2e11f03a40275a6ebbb70c0f37e5611cdd921cf/.github/actions/generate-native-package/native.sh#L65) in this repo.

## How to test
We'll update the iOS app to use the latest version of this repo when all the related PRs are in the right state, and will then do a smoke test of the app to verify that everything is working as expected.