### PR TITLE
Update to thrift-swift v0.21.0-gu2

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         // .package(url: /* package url */, from: "1.0.0"),
-        .package(url: "https://github.com/guardian/thrift-swift.git", .upToNextMinor(from: "0.19.0-gu1"))
+        .package(url: "https://github.com/guardian/thrift-swift.git", .upToNextMinor(from: "0.21.0-gu2"))
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.


### PR DESCRIPTION
## What does this change?
This updates bridget-swift to use the latest release of thrift-swift.

Now that https://github.com/guardian/bridget/pull/182 has been merged, and we have created a new [release](https://github.com/guardian/bridget/releases/tag/v8.2.0) of Bridget, a [new tag](https://github.com/guardian/bridget-swift/releases/tag/v8.2.0) has been [created](https://github.com/guardian/bridget/blob/c2e11f03a40275a6ebbb70c0f37e5611cdd921cf/.github/actions/generate-native-package/native.sh#L65) in this repo.

## How to test
We'll update the iOS app to use the latest version of this repo when all the related PRs are in the right state, and will then do a smoke test of the app to verify that everything is working as expected.